### PR TITLE
Made responsive svg background

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,5 +21,4 @@ jobs:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: >-
           git push -f https://heroku:${HEROKU_API_TOKEN}@git.heroku.com/${HEROKU_APP_NAME}.git
-          # origin/main:main
           ${GITHUB_REF##*/}:main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,8 @@ name: Deploy to Heroku
 on:
   push:
     branches:
-      - main
+      # - main
+      - "**" # Matches all branch and tag names.
   workflow_dispatch:
 
 jobs:
@@ -20,4 +21,5 @@ jobs:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: >-
           git push -f https://heroku:${HEROKU_API_TOKEN}@git.heroku.com/${HEROKU_APP_NAME}.git
-          origin/main:main
+          # origin/main:main
+          ${GITHUB_REF##*/}:main

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -43,17 +43,19 @@ main {
   }
   
   
-  svg { 
+  /* svg { 
     position:absolute; 
     top:0; left:0; height:100%; width:100%;
     z-index: -1;
-}
+} */
 
 .svg-container { 
 	display: inline-block;
 	position: relative;
-	max-width: 100%;
+	max-width: 100vw;
+  max-height: 100vh;
 	padding-bottom: 100%; 
 	vertical-align: middle; 
 	overflow: hidden; 
+  background: darkred;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -12,22 +12,6 @@ input, button {
     background-color: #222;
 }
 
-/* svg {
-    float: right;
-    display: block;
-}
-
-main {
-    display: flex;
-    flex-wrap: wrap;
-    padding-right: 0;
-    margin-right: 0;
-} */
-
-
-/* body {
-    background: black;
-  } */
   circle {
     fill: cadetblue;
   }
@@ -39,24 +23,28 @@ main {
     text-anchor: middle;
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     fill: #ccc;
-    font-size: .7rem;
+    font-size: .8rem;
   }
   
-  
-  /* svg { 
-    position:absolute; 
-    top:0; left:0; height:100%; width:100%;
-    z-index: -1;
-} */
-
 .svg-container { 
 	display: inline-block;
 	position: relative;
-	width: 100%;
-	padding-bottom: 100%; 
+	width: 100vmin;
+	/* padding-bottom: 100%;  */
 	vertical-align: middle; 
-	overflow: hidden; 
-  background: darkslategray;
+	/* overflow: hidden;  */
+  /* background: darkslategray; */
+
+  position:absolute; 
+  /* top:0; left:0;  */
+  top:0; 
+  right:0; 
+  /* max-height: 100vh; 
+  max-width: 100vw; */
+  z-index: -1;
+  transform: 
+    translateY(calc(55vh - 55vmin))
+    translateX(calc(-33vw + 33vmin));
 }
 
 .svg-content { 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -30,15 +30,13 @@ input, button {
 	display: inline-block;
 	position: relative;
 	width: 100vmin;
-	/* padding-bottom: 100%;  */
 	vertical-align: middle; 
 	/* overflow: hidden;  */
-  /* background: darkslategray; */
 
-  position:absolute; 
+  position: absolute; 
   /* top:0; left:0;  */
-  top:0; 
-  right:0; 
+  top: 0; 
+  right: 0; 
   /* max-height: 100vh; 
   max-width: 100vw; */
   z-index: -1;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -52,10 +52,16 @@ main {
 .svg-container { 
 	display: inline-block;
 	position: relative;
-	max-width: 100vw;
-  max-height: 100vh;
+	width: 100%;
 	padding-bottom: 100%; 
 	vertical-align: middle; 
 	overflow: hidden; 
-  background: darkred;
+  background: darkslategray;
+}
+
+.svg-content { 
+	display: inline-block;
+	position: absolute;
+	top: 0;
+	left: 0;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -25,9 +25,9 @@ main {
 } */
 
 
-body {
+/* body {
     background: black;
-  }
+  } */
   circle {
     fill: cadetblue;
   }
@@ -44,7 +44,16 @@ body {
   
   
   svg { 
-    position:fixed; 
+    position:absolute; 
     top:0; left:0; height:100%; width:100%;
     z-index: -1;
+}
+
+.svg-container { 
+	display: inline-block;
+	position: relative;
+	max-width: 100%;
+	padding-bottom: 100%; 
+	vertical-align: middle; 
+	overflow: hidden; 
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -39,7 +39,7 @@ main {
     text-anchor: middle;
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     fill: #ccc;
-    font-size: .8rem;
+    font-size: .7rem;
   }
   
   

--- a/app/src/components/Tree.js
+++ b/app/src/components/Tree.js
@@ -8,11 +8,13 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
       (svg) => {
         const height = 500;
         const width = 500;
+        const boxHeight = 600;
+        const boxWidth = 600;
         // const margin = { top: 20, right: 30, bottom: 30, left: 40 };
 
         d3.forceSimulation(nodes)
           .force('charge', d3.forceManyBody().strength(-400))
-          .force('center', d3.forceCenter(width/2, height/2))
+          .force('center', d3.forceCenter(boxWidth/2, boxHeight/2))
           .force('link', d3.forceLink().links(links))
           .on('tick', ticked);
         // console.log("line 18", simulation);
@@ -75,7 +77,7 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
       <div className="svg-container">
       <svg 
         version="1.1" 
-        viewBox="0 0 500 500" 
+        viewBox="0 0 600 600" 
         preserveAspectRatio="xMinYMin meet"
         className="svg-content"
         ref={ref}

--- a/app/src/components/Tree.js
+++ b/app/src/components/Tree.js
@@ -15,6 +15,7 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
         d3.forceSimulation(nodes)
           .force('charge', d3.forceManyBody().strength(-400))
           .force('center', d3.forceCenter(boxWidth/2, boxHeight/2))
+          // .force('center', d3.forceCenter(width/2, height/2))
           .force('link', d3.forceLink().links(links))
           .on('tick', ticked);
         // console.log("line 18", simulation);

--- a/app/src/components/Tree.js
+++ b/app/src/components/Tree.js
@@ -72,10 +72,14 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
     );
   
     return (
-
-      <svg
-       ref={ref}
-       style={{width: "100%", height: "100%"}}>
+      <div className="svg-container">
+      <svg 
+        version="1.1" 
+        viewBox="0 0 500 500" 
+        preserveAspectRatio="xMinYMin meet"
+        class="svg-content"
+        ref={ref}
+        style={{width: "100%", height: "100%"}}>
       <defs>
     <marker id="triangle" viewBox="0 0 10 10"
           refX="16.5" refY="5"
@@ -89,6 +93,7 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
       <g className="links"></g>
       <g className="nodes"></g>
     </svg>
+    </div>
 
     );
   }

--- a/app/src/components/Tree.js
+++ b/app/src/components/Tree.js
@@ -12,7 +12,7 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
 
         d3.forceSimulation(nodes)
           .force('charge', d3.forceManyBody().strength(-400))
-          .force('center', d3.forceCenter(width, height))
+          .force('center', d3.forceCenter(width/2, height/2))
           .force('link', d3.forceLink().links(links))
           .on('tick', ticked);
         // console.log("line 18", simulation);
@@ -77,9 +77,10 @@ function Tree({ links, nodes }) { // pink curlies = don’t worry about order of
         version="1.1" 
         viewBox="0 0 500 500" 
         preserveAspectRatio="xMinYMin meet"
-        class="svg-content"
+        className="svg-content"
         ref={ref}
-        style={{width: "100%", height: "100%"}}>
+        // style={{width: "100%", height: "100%"}}
+        >
       <defs>
     <marker id="triangle" viewBox="0 0 10 10"
           refX="16.5" refY="5"


### PR DESCRIPTION
This branch was branched out of the [`responsive`](https://github.com/picaq/prerequisite-tree/tree/responsive) branch. 
- at the HEAD commit of `responsive`, the svg fills the screen width. 

Trello Ticket: [make svg responsive](https://trello.com/c/wTc9FhkM/18-make-svg-responsive)

This [`responsive-bg`](https://github.com/picaq/prerequisite-tree/tree/responsive-bg) branch:
- makes the svg graphic fill the background
- is slightly off-center and responsive to the screen size
  - depends on whether the height or the width is the shortest via `translate: transform` in App.css
- submitting the input still breaks the app ( wip )